### PR TITLE
unk1

### DIFF
--- a/xlay/lay6.h
+++ b/xlay/lay6.h
@@ -148,7 +148,7 @@ struct LAY_Object
 
     UCHAR __pad_1_1[4];
     UINT16 component_id;
-    UCHAR unk1;
+    UCHAR selected;
 
     union {
         UCHAR th_style[4];


### PR DESCRIPTION
При сохранении с выделенным элементом устанавливается в 1. Но это бесполезно, так как при загрузке файла в SprintLayout все выделения сбрысываются.
